### PR TITLE
feat: 경로 정보 컴포넌트 초기 구현

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -28,3 +28,38 @@ export type InputSubmitContentPropsType = {
 export type LoadingPropsType = {
   className?: string;
 };
+
+export type Route = {
+  coordinates: SearchPlaceDataType[];
+  createdDate: string;
+  distance: string;
+  duration: string;
+  fuelPrice: string;
+  optionText: string;
+  routeId?: number;
+  routeOption: string;
+  searchId: number;
+  tollFare: string;
+};
+
+export type PathInfoType = Omit<
+  Route,
+  "coordinates" | "createdDate" | "searchId" | "routeOption" | "routeId"
+>;
+
+export type PathInfoPropsType = {
+  routeList: Route[];
+  setRouteList: Dispatch<SetStateAction<Route[] | undefined>>;
+  selectedRoute: Route | undefined;
+  setSelectedRoute: Dispatch<SetStateAction<Route | undefined>>;
+  startPlace: SearchPlaceDataType | null;
+  goalPlace: SearchPlaceDataType | null;
+  clickedMorePath: boolean;
+  setClickedMorePath: Dispatch<SetStateAction<boolean>>;
+  setRestSpotModalOpen: Dispatch<SetStateAction<boolean>>;
+};
+
+export type PathInfoContentPropsType = {
+  ranking: number;
+  route: PathInfoType;
+};


### PR DESCRIPTION
## 💡 개요 (필수)
사용자가 길찾기 버튼을 눌렀을시 선택한 장소에 따라 해당하는 경로 정보를 재사용할 수 있게 컴포넌트로 구현하였습니다.
<br/>

## 📃 작업내용 (필수)
- 경로 정보 컴포넌트를 `index`와 하위 컴포넌트인 `content `로 구현하였습니다.

<br/>
